### PR TITLE
multiple synchronous requests now possible; additional ObjectID stuff

### DIFF
--- a/src/as3/mongo/db/DB.as
+++ b/src/as3/mongo/db/DB.as
@@ -17,7 +17,7 @@ package as3.mongo.db
 	{
 		protected var _authenticated:Signal         = new Signal(DB);
 		protected var _authenticationProblem:Signal = new Signal(DB);
-		protected var _connected:Signal             = new Signal(DB);
+//		protected var _connected:Signal             = new Signal(DB);
 		protected var _connectionFailed:Signal      = new Signal(DB);
 		protected var _socketPolicyFileError:Signal = new Signal(DB);
 
@@ -41,12 +41,12 @@ package as3.mongo.db
 		{
 			return _connectionFailed;
 		}
-
+		/*
 		public function get connected():Signal
 		{
 			return _connected;
 		}
-
+		*/
 		public function get authenticationProblem():Signal
 		{
 			return _authenticationProblem;
@@ -76,12 +76,12 @@ package as3.mongo.db
 		{
 			return (_credentials is Credentials);
 		}
-
+		/*
 		public function get isConnected():Boolean
 		{
 			return _isConnected;
 		}
-
+		*/
 		public function get port():uint
 		{
 			return _port;
@@ -114,14 +114,14 @@ package as3.mongo.db
 
 		private function _initialize(databaseName:String, databaseHost:String, databasePort:uint):void
 		{
-			_wire = new Wire(this);
-
 			_collections = new Dictionary();
 			_authenticationFactory = new AuthenticationFactory();
 
 			_name = databaseName;
 			_host = databaseHost;
 			_port = databasePort;
+			
+			_wire = new Wire(this);
 		}
 
 		public function setCredentials(dbCredentials:Credentials):void
@@ -165,12 +165,12 @@ package as3.mongo.db
 		{
 			return wire.runCommand(command);
 		}
-
+		/*
 		public function connect():void
 		{
 			wire.connect();
 		}
-
+		*/
 		public function insert(collectionName:String, document:Document):void
 		{
 			wire.insert(name, collectionName, document);

--- a/src/as3/mongo/db/document/Document.as
+++ b/src/as3/mongo/db/document/Document.as
@@ -71,6 +71,17 @@ package as3.mongo.db.document
 		{
 			return _values[index];
 		}
+		
+		/**
+		 * ERICSOCO ADDED
+		 * I hate this fucking Document class....so bloated.
+		 */
+		public function getValueByKey(key:String):*
+		{
+			var index:uint = _keys.indexOf(key);
+			if (index == -1) { return null; }
+			else { return _values[index]; }
+		}
 
 		public function put(key:String, value:*):void
 		{

--- a/src/as3/mongo/db/document/Document.as
+++ b/src/as3/mongo/db/document/Document.as
@@ -74,7 +74,6 @@ package as3.mongo.db.document
 		
 		/**
 		 * ERICSOCO ADDED
-		 * I hate this fucking Document class....so bloated.
 		 */
 		public function getValueByKey(key:String):*
 		{

--- a/src/as3/mongo/db/document/Document.as
+++ b/src/as3/mongo/db/document/Document.as
@@ -1,7 +1,7 @@
 package as3.mongo.db.document
 {
 	import as3.mongo.error.MongoError;
-
+	
 	import org.serialization.bson.ObjectID;
 
 	public class Document
@@ -77,16 +77,80 @@ package as3.mongo.db.document
 		 */
 		public function getValueByKey(key:String):*
 		{
-			var index:uint = _keys.indexOf(key);
+			var index:int = _keys.indexOf(key);
 			if (index == -1) { return null; }
 			else { return _values[index]; }
 		}
 
 		public function put(key:String, value:*):void
 		{
+			/**
+			 * ERICSOCO ADDED
+			 */
+			var existingIndex:int = _keys.indexOf(key);
+			if (existingIndex != -1) {
+				_values[existingIndex] = value;
+				return;
+			}
+			
 			const nextIndex:Number = _keys.length;
 			_keys[nextIndex] = key;
 			_values[nextIndex] = value;
+		}
+		
+		/**
+		 * ERICSOCO ADDED
+		 */
+		public function remove (key:String) :void {
+			var existingIndex:int = _keys.indexOf(key);
+			if (existingIndex != -1) {
+				_keys.splice(existingIndex, 1);
+				_values.splice(existingIndex, 1);
+			}
+		}
+		
+		/**
+		 * ERICSOCO ADDED
+		 */
+		public function toString (tabLevel:int=0) :String {
+			function addTabs () :String {
+				var tabStr:String = "";
+				for (var t:int=0; t<tabLevel; t++) {
+					tabStr += "\t";
+				}
+				return tabStr;
+			}
+			
+			var output:String = addTabs() + "{\n";
+			var len:int = _keys.length;
+			var value:*;
+			
+			tabLevel++;
+			for (var i:int=0; i<len; i++) {
+				output += addTabs();
+				output += (_keys[i] + " : ");
+				
+				value = _values[i];
+				if (value is Document) {
+					output += Document(value).toString(tabLevel);
+				} else if (value is Array) {
+					var arr:Array = value as Array;
+					output += "[\n";
+					tabLevel++;
+					for (var j:int=0; j<arr.length; j++) {
+						output += (arr[j].toString(tabLevel) + ",\n");
+					}
+					tabLevel--;
+					output += (addTabs() + "]");
+				} else {
+					output += String(value);
+				}
+				output += "\n";
+			}
+			tabLevel--;
+			
+			output += (addTabs() + "}")
+			return output;
 		}
 	}
 }

--- a/src/as3/mongo/wire/RequestSequence.as
+++ b/src/as3/mongo/wire/RequestSequence.as
@@ -1,0 +1,105 @@
+package as3.mongo.wire {
+	import as3.mongo.wire.cursor.Cursor;
+	import as3.mongo.wire.messages.IMessage;
+	import as3.mongo.wire.messages.database.OpReply;
+	import as3.mongo.wire.messages.database.OpReplyLoader;
+	
+	import com.transmote.utils.time.Timeout;
+	
+	import flash.events.ErrorEvent;
+	import flash.events.Event;
+	import flash.events.EventDispatcher;
+	import flash.events.IOErrorEvent;
+	import flash.events.SecurityErrorEvent;
+	import flash.net.Socket;
+
+	public class RequestSequence extends EventDispatcher {
+		private var query:IMessage;
+		private var replyLoader:OpReplyLoader;
+		private var socket:Socket;
+		private var cursor:Cursor;
+		
+		public function RequestSequence (query:IMessage, replyLoader:OpReplyLoader, cursor:Cursor=null) {
+			this.query = query;
+			this.replyLoader = replyLoader;
+			this.cursor = cursor;
+			
+			init();
+		}
+		
+		public function begin (host:String, port:int) :void {
+			if (!socket.connected) {
+				socket.connect(host, port);
+			} else {
+				// force asynchronicity
+				var beginTimeout:Timeout = new Timeout(beginSequence, 1);
+			}
+		}
+		
+		private function init () :void {
+			initSocket();
+		}
+		
+		
+		
+		//-----<REQUEST SEQUENCE>------------------------------------//
+		private function beginSequence () :void {
+			initReplyLoader();
+			doQuery();
+		}
+		
+		private function initReplyLoader () :void {
+			replyLoader.initializeOpReplyLoader(socket);
+			replyLoader.LOADED.addOnce(onReplyLoaded);
+		}
+		
+		private function doQuery () :void {
+			socket.writeBytes(query.toByteArray());
+			socket.flush();
+		}
+		
+		private function onReplyLoaded (reply:OpReply) :void {
+			if (cursor) {
+				cursor.onReplyLoaded(reply);
+			}
+			
+			closeSocket();
+			dispatchEvent(new Event(Event.COMPLETE));
+		}
+		//-----</REQUEST SEQUENCE>-----------------------------------//
+		
+		
+		
+		//-----<SOCKET MANAGEMENT>-----------------------------------//
+		private function initSocket () :void {
+			socket = new Socket();
+			socket.addEventListener(IOErrorEvent.IO_ERROR, onSocketReady);
+			socket.addEventListener(SecurityErrorEvent.SECURITY_ERROR, onSocketReady);
+			socket.addEventListener(Event.CONNECT, onSocketReady);
+		}
+		
+		private function onSocketReady (evt:Event) :void {
+			var socket:Socket = evt.target as Socket;
+			if (!socket) { return; }
+			socket.removeEventListener(IOErrorEvent.IO_ERROR, onSocketReady);
+			socket.removeEventListener(SecurityErrorEvent.SECURITY_ERROR, onSocketReady);
+			socket.removeEventListener(Event.CONNECT, onSocketReady);
+			
+			if (evt is ErrorEvent) {
+				dispatchEvent(evt);
+				return;
+			}
+			
+			beginSequence();
+		}
+		
+		private function closeSocket () :void {
+			try {
+				socket.close();
+			} catch (e:Error) {}
+			
+			socket = null;
+		}
+		//-----</SOCKET MANAGEMENT>----------------------------------//		
+	}
+}

--- a/src/as3/mongo/wire/messages/database/FindOneOpReplyLoader.as
+++ b/src/as3/mongo/wire/messages/database/FindOneOpReplyLoader.as
@@ -6,14 +6,14 @@ package as3.mongo.wire.messages.database
 
 	public class FindOneOpReplyLoader extends OpReplyLoader
 	{
-		public function FindOneOpReplyLoader(aSocket:Socket)
+		public function FindOneOpReplyLoader()
 		{
-			super(aSocket);
+			//
 		}
 
-		override protected function _initializeOpReplyLoader(aSocket:Socket):void
+		override public function initializeOpReplyLoader(aSocket:Socket):void
 		{
-			super._initializeOpReplyLoader(aSocket);
+			super.initializeOpReplyLoader(aSocket);
 
 			_LOADED = new Signal(FindOneResult);
 		}

--- a/src/as3/mongo/wire/messages/database/OpReplyLoader.as
+++ b/src/as3/mongo/wire/messages/database/OpReplyLoader.as
@@ -16,9 +16,9 @@ package as3.mongo.wire.messages.database
 		protected var _currentReplyLength:int;
 		protected var _amountOfBytesLoaded:uint;
 
-		public function OpReplyLoader(aSocket:Socket)
+		public function OpReplyLoader()
 		{
-			_initializeOpReplyLoader(aSocket);
+			_LOADED = new Signal(OpReply);
 		}
 
 		public function get opReply():OpReply
@@ -41,11 +41,10 @@ package as3.mongo.wire.messages.database
 			return _socket;
 		}
 
-		protected function _initializeOpReplyLoader(aSocket:Socket):void
+		public function initializeOpReplyLoader(aSocket:Socket):void
 		{
 			_socket = aSocket;
 			_socket.addEventListener(ProgressEvent.SOCKET_DATA, _handleSocketData, false, 0, true);
-			_LOADED = new Signal(OpReply);
 		}
 
 		private function _handleSocketData(event:ProgressEvent):void

--- a/src/org/serialization/bson/ObjectID.as
+++ b/src/org/serialization/bson/ObjectID.as
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010 Claudio Alberto Andreoni.
+ * Modifications by Eric Socolofsky: http://transmote.com.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,24 +22,29 @@
  *
  */
 
-package org.serialization.bson
-{
+package org.serialization.bson {
+	import flash.net.NetworkInfo;
+	import flash.net.NetworkInterface;
 	import flash.utils.ByteArray;
 	import flash.utils.Endian;
 
-	public class ObjectID extends Object
-	{
+	public class ObjectID {
+		private static var incrementer : uint = Math.random() * uint.MAX_VALUE;
+		private static var machineAndProcessID : ByteArray = null;
 
 		// BSON is little-endian
-		private var rep:ByteArray;
+		private var rep : ByteArray;
+		private var time : uint;
 
 		/**
 		 * @brief Create a new ObjectID
 		 * @param bytearray A little-endian, 12-byte ByteArray containing the ID
 		 */
-		public function ObjectID(bytearray:ByteArray):void
-		{
-			setFromBytes(bytearray);
+		public function ObjectID( bytearray : ByteArray = null ) :void {
+			if (bytearray == null) {
+				bytearray = generateObjectID();
+			}
+			setFromBytes( bytearray );
 		}
 
 
@@ -47,13 +53,14 @@ package org.serialization.bson
 		 * @brief Set the value of this ObjectID
 		 * @param bytearray A little-endian, 12-byte ByteArray containing the ID
 		 */
-		public function setFromBytes(bytearray:ByteArray):void
-		{
+		public function setFromBytes( bytearray : ByteArray ) :void {
 			rep = new ByteArray();
-			for (var i:int = 0; i < 12; ++i)
-			{
+			for ( var i : int = 0; i < 12; ++i ) {
 				rep[i] = bytearray.readByte();
 			}
+			
+			time = rep.readUnsignedInt();
+			rep.position = 0;
 		}
 
 
@@ -62,19 +69,80 @@ package org.serialization.bson
 		 * @brief Get the value of this ObjectID
 		 * @return A little-endian, 12-byte ByteArray containing the ID
 		 */
-		public function getAsBytes():ByteArray
-		{
+		public function getAsBytes() : ByteArray {
 			return rep;
 		}
 
-		public function toString():String
-		{
+		public function toString() : String {
 			var str:String = "";
-			for (var i:int = 0; i < 12; ++i)
-			{
-				str += rep[i].toString(16);
+			for ( var i : int = 0; i < 12; ++i ) {
+				str += rep[i].toString( 16 );
 			}
 			return str;
+		}
+		
+		public function toDate() : Date {
+			return new Date( time * 1000 );
+		}
+		
+		private function generateObjectID() :ByteArray {
+			// from: http://www.mongodb.org/display/DOCS/Object+IDs
+			
+			// 4-byte timestamp
+			time = new Date().getTime();
+			var timeBytes:ByteArray = new ByteArray();
+			timeBytes.endian = Endian.BIG_ENDIAN;
+			timeBytes.writeInt( time );
+			timeBytes.length = 4;	// truncate as needed
+			
+			// 3-byte machine id + 2-byte process id
+			if ( machineAndProcessID == null ) {
+				generateMachineID();
+			}
+			
+			// 3-byte increment
+			var incBytes:ByteArray = new ByteArray();
+			incBytes.endian = Endian.BIG_ENDIAN;
+			incBytes.writeUnsignedInt( incrementer++ );
+			incBytes.length = 3;		// truncate as needed
+			
+			var idBytes:ByteArray = new ByteArray();
+			idBytes.writeBytes( timeBytes );
+			idBytes.writeBytes( machineAndProcessID );
+			idBytes.writeBytes( incBytes );
+			
+			idBytes.position = 0;
+			return idBytes;
+		}
+		
+		private function generateMachineID() :void {
+			machineAndProcessID = new ByteArray();
+			machineAndProcessID.endian = Endian.LITTLE_ENDIAN;
+			
+			var useRandom:Boolean = true;
+			for each ( var i : NetworkInterface in NetworkInfo.networkInfo.findInterfaces() ) {
+				if ( i.hardwareAddress ) {
+					machineAndProcessID.writeUTFBytes( i.hardwareAddress );
+					useRandom = false;
+					break;
+				}
+			}
+			
+			if ( useRandom ) {
+				// if no NetworkInterfaces with valid hardware addresses found, use random
+				var randomMachineID : uint = Math.floor( Math.random() * uint.MAX_VALUE );
+				machineAndProcessID.writeUnsignedInt( randomMachineID );
+			}
+			
+			machineAndProcessID.length = 3;		// truncate as needed
+			
+			// not possible to get process id from flash without launching a NativeProcess,
+			// which requires AIR application with extendedDesktop profile.
+			// so, use a random.
+			var processID:uint = Math.floor( Math.random() * uint.MAX_VALUE );
+			machineAndProcessID.writeUnsignedInt( processID );
+			
+			machineAndProcessID.length = 5;		// truncate as needed
 		}
 	}
 }


### PR DESCRIPTION
heavy edits to Wire.as to allow multiple synchronous requests (by using
multiple sockets); previously, multiple requests at the same time would
fail silently.

now that Wire manages multiple Socket instances (via RequestSequence),
DB.connect() is no longer necessary.  just make requests directly.
error handlers are still piped back up via DB error Signals.

moved Wire away from dependency on Signals, though they're still used
throughout the rest of MongoAS3.

added new ObjectID generation (so inserts don't have to getLastError to
access an ObjectID generated by the server on a newly-inserted
document).

added timestamp extraction to ObjectID.

sorry about formatting differences from original MongoAS3.
